### PR TITLE
kugo: fix nfc dev path

### DIFF
--- a/rootdir/system/etc/libnfc-nxp.conf
+++ b/rootdir/system/etc/libnfc-nxp.conf
@@ -19,7 +19,7 @@ NXPLOG_TML_LOGLEVEL=0x01
 
 ###############################################################################
 # Nfc Device Node name
-NXP_NFC_DEV_NODE="/dev/pn544"
+NXP_NFC_DEV_NODE="/dev/pn54x"
 
 ###############################################################################
 # File name for Firmware


### PR DESCRIPTION
PN547 looks aroung /dev/pn54x not /dev/pn544

Signed-off-by: David Viteri <davidteri91@gmail.com>