### PR TITLE
kugo: config: Use unique variables for device paths

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -12,18 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Device path
+DEVICE_PATH := $(DEVICE_PATH)
+
 DEVICE_PACKAGE_OVERLAYS += \
-    device/sony/kugo/overlay
+    $(DEVICE_PATH)/overlay
 
 PRODUCT_COPY_FILES := \
-    device/sony/kugo/rootdir/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
-    device/sony/kugo/rootdir/system/etc/BCM4345.hcd:system/etc/firmware/BCM43xx.hcd \
-    device/sony/kugo/rootdir/system/etc/wifi/bcmdhd.cal:system/etc/wifi/bcmdhd.cal \
-    device/sony/kugo/rootdir/system/etc/sensors/sensor_def_qcomdev.conf:system/etc/sensors/sensor_def_qcomdev.conf \
-    device/sony/kugo/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \
-    device/sony/kugo/rootdir/system/etc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
-    device/sony/kugo/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
-    device/sony/kugo/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
+    $(DEVICE_PATH)/rootdir/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
+    $(DEVICE_PATH)/rootdir/system/etc/BCM4345.hcd:system/etc/firmware/BCM43xx.hcd \
+    $(DEVICE_PATH)/rootdir/system/etc/wifi/bcmdhd.cal:system/etc/wifi/bcmdhd.cal \
+    $(DEVICE_PATH)/rootdir/system/etc/sensors/sensor_def_qcomdev.conf:system/etc/sensors/sensor_def_qcomdev.conf \
+    $(DEVICE_PATH)/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \
+    $(DEVICE_PATH)/rootdir/system/etc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
+    $(DEVICE_PATH)/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
+    $(DEVICE_PATH)/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
 
 # Device Specific Permissions
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
 * Avoid hardcoding the paths by using common
    variables declared once for path accesses

Change-Id: I85bf3f9ec81b585daa0330149ebb873ada5335bf
Signed-off-by: Adrian DC <radian.dc@gmail.com>