### PR TITLE
kugo: config: Really use a unique variable for device path

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Device path
-DEVICE_PATH := $(DEVICE_PATH)
+DEVICE_PATH := device/sony/kugo
 
 DEVICE_PACKAGE_OVERLAYS += \
     $(DEVICE_PATH)/overlay


### PR DESCRIPTION
 * The real path definition got replaced before final commit

Change-Id: Ibeaeec3057302be5a455f1f4ec7597b3084e16ea
Signed-off-by: Adrian DC <radian.dc@gmail.com>