### PR TITLE
kugo: remove not needed daemon fingerprint

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -67,7 +67,6 @@ PRODUCT_PACKAGES += \
 
 # Fingerprint HAL
 PRODUCT_PACKAGES += \
-    fingerprintd \
     fingerprint.kugo
 
 # NFC config


### PR DESCRIPTION
daemon fingerprint is not more on android oreo it was replaced by android.hardware.biometrics.fingerprint

Signed-off-by: David Viteri <davidteri91@gmail.com>