### PR TITLE
rootdir: vendor: increase speaker volume

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -1826,8 +1826,8 @@
         <ctl name="SLIM_0_RX Channels" value="Two" />
         <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
         <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX7 Digital Volume" value="82" />
-        <ctl name="RX8 Digital Volume" value="82" />
+        <ctl name="RX7 Digital Volume" value="92" />
+        <ctl name="RX8 Digital Volume" value="92" />
         <ctl name="SpkrLeft COMP Switch" value="1" />
         <ctl name="SpkrRight COMP Switch" value="1" />
         <ctl name="SpkrLeft BOOST Switch" value="1" />


### PR DESCRIPTION
When speakers are in use, do not decrease their volume from the initial 84 to 82.
Increasing to 92 delivers acceptable loudness with minimal distortion.

Change-Id: I84e187a13053e01b47cea7cd10cf256e154b95e5