### PR TITLE
rootdir: vendor: increase microphone gain

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -2878,8 +2878,8 @@
 
     <path name="handset-stereo-dmic-ef">
         <path name="camcorder-mic-common" />
-        <ctl name="DEC8 Volume" value="101" />
-        <ctl name="DEC7 Volume" value="83" />
+        <path name="dmic1-adj-gain" />
+        <path name="dmic2-adj-gain" />
     </path>
 
     <path name="speaker-stereo-dmic-ef">


### PR DESCRIPTION
The path "handset-stereo-dmic-ef" is used for multiple usecases like recording and camera.
There are already paths for the microphone gains, used for voice usecases, which happen to use higher values.
Reference those to help boost captured audio gain, and also centralize the values instead of duplicating each time.