### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -79,10 +79,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.kugo
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.kugo
-
 # Telephony Packages (AOSP)
 PRODUCT_PACKAGES += \
     InCallUI \


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.