### PR TITLE
device: declare brcmfmac as the used wifi driver

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -18,6 +18,9 @@ DEVICE_PATH := device/sony/kugo/rootdir
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/kugo/overlay
 
+# declare brcmfmac as the wifi driver
+WIFI_DRIVER_BUILT := brcmfmac
+
 # Device Specific Permissions
 PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/handheld_core_hardware.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/handheld_core_hardware.xml \


### PR DESCRIPTION
this is needed so that the firmware can be copied to the paths expected by the driver.